### PR TITLE
Prep v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNPUBLISHED
+## [1.1.0] - 2024-10-21
+
+<small>[Compare to previous release][comp:1.1.0]</small>
 
 ### Added
 
@@ -43,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Developer dependency bumps (no user-facing changes)
 -   Added CI based testing for every PR
+
+[comp:1.1.0]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/compare/v1.0.1...v1.1.0
+[1.1.0]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/release/tag/v1.1.0
 
 ## [1.0.1] - 2023-11-14
 
@@ -61,11 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Developer dependency bumps (no user-facing changes)
 -   Updated publish action, `tslib` requirement and node version (no user-facing changes)
 
+[comp:1.0.1]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/compare/v1.0.0...v1.0.1
+[1.0.1]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/release/tag/v1.0.1
+
 ## [1.0.0] - 2022-12-13
 
 **This was the first release**
 
-[comp:1.0.1]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/compare/v1.0.0...v1.0.1
-[1.0.1]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/release/tag/v1.0.1
 [1.0.0]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/release/tag/v1.0.0
 [cl:tp]: https://github.com/TopMarksDevelopment/JavaScript.Position/blob/main/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Autocomplete (A JavaScript package)
 
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/TopMarksDevelopment/JavaScript.Autocomplete/test.yml?style=for-the-badge&label=Tests)](https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/actions/workflows/test.yml)
+
 A small package to provide an autocomplete list as a user is typing.
 
 ### Contents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@topmarksdevelopment/autocomplete",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@topmarksdevelopment/autocomplete",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "@topmarksdevelopment/position": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@topmarksdevelopment/autocomplete",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Autocomplete user input - similar to JQuery UI Autocomplete",
     "author": "TopMarksDevelopment",
     "license": "MIT",


### PR DESCRIPTION
## 1.1.0 - 2024-10-21

<small>[Compare to previous release][comp:1.1.0]</small>

### Added

-   A string `source` can now contain `{{term}}`, to accommodate paths where `?term=XXX` isn't suitable
    -   This means you could now use `example.com/search/{{term}}/other-stuff`

### Fixed

-   The mouse being over the popup when it's rendered no longer selects that value whilst typing
-   A string `source` can now contain a query string (`?`)
    -   It now checks the source and adds either `?` or `&`, whichever is appropriate

### Changes

-   Developer dependency bumps (no user-facing changes)
-   Added CI based testing for every PR

[comp:1.1.0]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/compare/v1.0.1...v1.1.0