### PR TITLE
Prep for v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2024-11-08
+
+<small>[Compare to previous release][comp:1.1.1]</small>
+
+### Fixed
+
+-   Fixed the package missing library data
+
+[comp:1.1.1]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/compare/v1.1.0...v1.1.1
+[1.1.1]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/release/tag/v1.1.1
+
 ## [1.1.0] - 2024-10-21
 
 <small>[Compare to previous release][comp:1.1.0]</small>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@topmarksdevelopment/autocomplete",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@topmarksdevelopment/autocomplete",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "license": "MIT",
             "dependencies": {
                 "@topmarksdevelopment/position": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@topmarksdevelopment/autocomplete",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Autocomplete user input - similar to JQuery UI Autocomplete",
     "author": "TopMarksDevelopment",
     "license": "MIT",
@@ -36,6 +36,7 @@
         "build": "rollup --bundleConfigAsCjs -c rollup.config.js",
         "format": "prettier --write \"src/**/*.ts\"",
         "lint": "eslint ./src",
+        "prepare": "npm run build",
         "prepublishOnly": "npm run lint"
     },
     "dependencies": {


### PR DESCRIPTION
# 1.1.1 - 2024-11-08

<small>[Compare to previous release][comp:1.1.1]</small>

### Fixed

-   Fixed the package missing library data

[comp:1.1.1]: https://github.com/TopMarksDevelopment/JavaScript.Autocomplete/compare/v1.1.0...v1.1.1